### PR TITLE
Make dbpath required

### DIFF
--- a/src/MikeBell/GhostToSculpin/Migrate.php
+++ b/src/MikeBell/GhostToSculpin/Migrate.php
@@ -16,7 +16,7 @@ class Migrate extends Command
             ->setDescription('Run Ghost to Sculpin migrate')
             ->addArgument(
                 'dbpath',
-                InputArgument::OPTIONAL,
+                InputArgument::REQUIRED,
                 'Path to sqlite db.'
             )
         ;


### PR DESCRIPTION
Should `dbpath` be required?